### PR TITLE
Add long poll fallback when WebSocket fails

### DIFF
--- a/client/src/util/apollo.js
+++ b/client/src/util/apollo.js
@@ -33,7 +33,7 @@ function createPhoenixSocket() {
   });
   socket.onError(() => {
     if (navigator.onLine) {
-      const isWebSocket = socket.transport == window.WebSocket;
+      const isWebSocket = socket.transport === window.WebSocket;
       console.error(
         `Error connecting using ${isWebSocket ? "WebSocket" : "LongPoll"}`,
       );

--- a/client/src/util/apollo.js
+++ b/client/src/util/apollo.js
@@ -2,7 +2,7 @@ import ApolloClient from "apollo-client";
 import { InMemoryCache } from "apollo-cache-inmemory";
 import * as AbsintheSocket from "@absinthe/socket";
 import { createAbsintheSocketLink } from "@absinthe/socket-apollo-link";
-import { Socket as PhoenixSocket } from "phoenix";
+import { Socket as PhoenixSocket, LongPoll } from "phoenix";
 import { createHttpLink } from "apollo-link-http";
 import { hasSubscription } from "@jumpn/utils-graphql";
 import { split } from "apollo-link";
@@ -19,22 +19,37 @@ const WS_URI =
     ? "wss://brisk-hospitable-indianelephant.gigalixirapp.com/socket"
     : "ws://localhost:4000/socket";
 
+function createPhoenixSocket() {
+  // Socket with full fallback to LongPoll
+  // via https://elixirforum.com/t/fall-back-to-longpoll-when-websocket-fails/23894
+  const socket = new PhoenixSocket(WS_URI, {
+    params: () => {
+      if (Cookies.get("token")) {
+        return { token: Cookies.get("token") };
+      } else {
+        return {};
+      }
+    },
+  });
+  socket.onError(() => {
+    if (navigator.onLine) {
+      const isWebSocket = socket.transport == window.WebSocket;
+      console.error(
+        `Error connecting using ${isWebSocket ? "WebSocket" : "LongPoll"}`,
+      );
+      if (isWebSocket) socket.transport = LongPoll;
+      else if (window.WebSocket) socket.transport = window.WebSocket;
+    }
+  });
+  return socket;
+}
+
 export const createClient = ({ ssr, req, fetch, tokenCookie } = {}) => {
   let link = createHttpLink({ uri: HTTP_URI, fetch });
   let absintheSocket;
 
   if (!ssr) {
-    absintheSocket = AbsintheSocket.create(
-      new PhoenixSocket(WS_URI, {
-        params: () => {
-          if (Cookies.get("token")) {
-            return { token: Cookies.get("token") };
-          } else {
-            return {};
-          }
-        },
-      }),
-    );
+    absintheSocket = AbsintheSocket.create(createPhoenixSocket());
     const socketLink = createAbsintheSocketLink(absintheSocket);
 
     link = split(


### PR DESCRIPTION
From https://elixirforum.com/t/fall-back-to-longpoll-when-websocket-fails/23894

As by default Phoenix will only fallback if `window.WebSocket` isn't available, not if the connection fails (e.g. a blocking proxy)